### PR TITLE
Adding support for hd-downloader to download right package for a windows machine too

### DIFF
--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -202,13 +202,13 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 
 					if packageURL == "" {
 						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.%s",
-							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, getPackagingFormat(o))
+							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, packagingFormat)
 					}
 				} else {
 					hdPkg.VersionNum = common.ParseVersionNum(version)
 					if packageURL == "" {
 						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.%s",
-							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, getPackagingFormat(o))
+							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, packagingFormat)
 					}
 				}
 
@@ -227,9 +227,11 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 
 					var buf bytes.Buffer
 					if err = tmp.Execute(&buf, hdPkg); err == nil {
-						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s.%s",
-							o.Org, o.Repo, version, buf.String(), getPackagingFormat(o))
-
+						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
+							o.Org, o.Repo, version, buf.String())
+						if !strings.HasSuffix(packageURL, "tar.gz") || !strings.HasSuffix(packageURL, "zip") {
+							packageURL = fmt.Sprintf("%s.%s", packageURL, packagingFormat)
+						}
 						o.Output = buf.String()
 					} else {
 						return

--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -229,7 +229,7 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 					if err = tmp.Execute(&buf, hdPkg); err == nil {
 						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
 							o.Org, o.Repo, version, buf.String())
-						if !strings.HasSuffix(packageURL, "tar.gz") || !strings.HasSuffix(packageURL, "zip") {
+						if !strings.HasSuffix(packageURL, "tar.gz") && !strings.HasSuffix(packageURL, "zip") {
 							packageURL = fmt.Sprintf("%s.%s", packageURL, packagingFormat)
 						}
 						o.Output = buf.String()

--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -204,14 +204,14 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 					}
 
 					if packageURL == "" {
-						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.tar.gz",
-							o.Org, o.Repo, version, o.Name, o.OS, o.Arch)
+						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.%s",
+							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, getPackagingFormat(o))
 					}
 				} else {
 					hdPkg.VersionNum = common.ParseVersionNum(version)
 					if packageURL == "" {
-						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.tar.gz",
-							o.Org, o.Repo, version, o.Name, o.OS, o.Arch)
+						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.%s",
+							o.Org, o.Repo, version, o.Name, o.OS, o.Arch, getPackagingFormat(o))
 					}
 				}
 
@@ -354,11 +354,9 @@ func chooseOneFromArray(options []string) (result string, err error) {
 }
 
 func getPackagingFormat(installer *Installer) string {
-	switch strings.ToLower(installer.OS) {
-	case "windows":
+	platformType := strings.ToLower(installer.OS)
+	if platformType == "windows" {
 		return installer.Package.FormatOverrides.Windows
-	case "linux":
-		return installer.Package.FormatOverrides.Linux
 	}
-	return ""
+	return installer.Package.FormatOverrides.Linux
 }

--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -152,9 +152,6 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 		return
 	}
 	packagingFormat := getPackagingFormat(o)
-	if packagingFormat == "" {
-		return
-	}
 	if version == "latest" {
 		packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/%s/download/%s-%s-%s.%s",
 			o.Org, o.Repo, version, o.Name, o.OS, o.Arch, packagingFormat)

--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -230,8 +230,8 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 
 					var buf bytes.Buffer
 					if err = tmp.Execute(&buf, hdPkg); err == nil {
-						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
-							o.Org, o.Repo, version, buf.String())
+						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s.%s",
+							o.Org, o.Repo, version, buf.String(), getPackagingFormat(o))
 
 						o.Output = buf.String()
 					} else {
@@ -356,7 +356,13 @@ func chooseOneFromArray(options []string) (result string, err error) {
 func getPackagingFormat(installer *Installer) string {
 	platformType := strings.ToLower(installer.OS)
 	if platformType == "windows" {
-		return installer.Package.FormatOverrides.Windows
+		if installer.Package != nil {
+			return installer.Package.FormatOverrides.Windows
+		}
+		return "zip"
 	}
-	return installer.Package.FormatOverrides.Linux
+	if installer.Package != nil {
+		return installer.Package.FormatOverrides.Linux
+	}
+	return "tar.gz"
 }

--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -151,13 +151,16 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 	if err != nil {
 		return
 	}
-
+	packagingFormat := getPackagingFormat(o)
+	if packagingFormat == "" {
+		return
+	}
 	if version == "latest" {
-		packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/%s/download/%s-%s-%s.tar.gz",
-			o.Org, o.Repo, version, o.Name, o.OS, o.Arch)
+		packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/%s/download/%s-%s-%s.%s",
+			o.Org, o.Repo, version, o.Name, o.OS, o.Arch, packagingFormat)
 	} else {
-		packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.tar.gz",
-			o.Org, o.Repo, version, o.Name, o.OS, o.Arch)
+		packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s-%s-%s.%s",
+			o.Org, o.Repo, version, o.Name, o.OS, o.Arch, packagingFormat)
 	}
 
 	// try to parse from config
@@ -348,4 +351,14 @@ func chooseOneFromArray(options []string) (result string, err error) {
 	}
 	err = survey.AskOne(prompt, &result)
 	return
+}
+
+func getPackagingFormat(installer *Installer) string {
+	switch strings.ToLower(installer.OS) {
+	case "windows":
+		return installer.Package.FormatOverrides.Windows
+	case "linux":
+		return installer.Package.FormatOverrides.Linux
+	}
+	return ""
 }

--- a/pkg/installer/check_test.go
+++ b/pkg/installer/check_test.go
@@ -97,8 +97,8 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 			packageURL: "orgtest/repotest",
 			verify: func(o *Installer, packageURL string, t *testing.T) {
 				expectURL := fmt.Sprintf(
-					"https://github.com/orgtest/repotest/releases/latest/download/repotest-%s-%s.tar.gz",
-					o.OS, o.Arch)
+					"https://github.com/orgtest/repotest/releases/latest/download/repotest-%s-%s.%s",
+					o.OS, o.Arch, getPackagingFormat(o))
 				assert.Equal(t, packageURL, expectURL)
 			},
 			wantErr: false,
@@ -108,8 +108,8 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 			packageURL: "orgtest/repotest/hello",
 			verify: func(o *Installer, packageURL string, t *testing.T) {
 				expectURL := fmt.Sprintf(
-					"https://github.com/orgtest/repotest/releases/latest/download/hello-%s-%s.tar.gz",
-					o.OS, o.Arch)
+					"https://github.com/orgtest/repotest/releases/latest/download/hello-%s-%s.%s",
+					o.OS, o.Arch, getPackagingFormat(o))
 				assert.Equal(t, packageURL, expectURL)
 			},
 			wantErr: false,
@@ -119,8 +119,8 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 			packageURL: "orgtest/repotest/hello@v1.0",
 			verify: func(o *Installer, packageURL string, t *testing.T) {
 				expectURL := fmt.Sprintf(
-					"https://github.com/orgtest/repotest/releases/download/v1.0/hello-%s-%s.tar.gz",
-					o.OS, o.Arch)
+					"https://github.com/orgtest/repotest/releases/download/v1.0/hello-%s-%s.%s",
+					o.OS, o.Arch, getPackagingFormat(o))
 				assert.Equal(t, packageURL, expectURL)
 			},
 			wantErr: false,
@@ -130,8 +130,8 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 			packageURL: "orgtest/repotest/hello@hello/v1.0",
 			verify: func(o *Installer, packageURL string, t *testing.T) {
 				expectURL := fmt.Sprintf(
-					"https://github.com/orgtest/repotest/releases/download/hello/v1.0/hello-%s-%s.tar.gz",
-					o.OS, o.Arch)
+					"https://github.com/orgtest/repotest/releases/download/hello/v1.0/hello-%s-%s.%s",
+					o.OS, o.Arch, getPackagingFormat(o))
 				assert.Equal(t, packageURL, expectURL)
 			},
 			wantErr: false,
@@ -141,8 +141,8 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 			packageURL: "orgtest/repotest/hello@hello_v1.0",
 			verify: func(o *Installer, packageURL string, t *testing.T) {
 				expectURL := fmt.Sprintf(
-					"https://github.com/orgtest/repotest/releases/download/hello_v1.0/hello-%s-%s.tar.gz",
-					o.OS, o.Arch)
+					"https://github.com/orgtest/repotest/releases/download/hello_v1.0/hello-%s-%s.%s",
+					o.OS, o.Arch, getPackagingFormat(o))
 				assert.Equal(t, packageURL, expectURL)
 			},
 			wantErr: false,
@@ -152,6 +152,10 @@ func TestProviderURLParseNoConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			is := &Installer{
+				Package: &HDConfig{FormatOverrides: PackagingFormat{
+					Windows: "zip",
+					Linux:   "tar.gz",
+				}},
 				OS:   runtime.GOOS,
 				Arch: runtime.GOARCH,
 			}

--- a/pkg/installer/types.go
+++ b/pkg/installer/types.go
@@ -1,5 +1,6 @@
 package installer
 
+// PackagingFormat is used for containing config depending on machine
 type PackagingFormat struct {
 	Windows string `yaml:"windows"`
 	Linux   string `yaml:"linux"`

--- a/pkg/installer/types.go
+++ b/pkg/installer/types.go
@@ -1,9 +1,15 @@
 package installer
 
+type PackagingFormat struct {
+	Windows string `yaml:"windows"`
+	Linux   string `yaml:"linux"`
+}
+
 // HDConfig is the config of http-downloader
 type HDConfig struct {
 	Name             string            `yaml:"Name"`
 	Filename         string            `yaml:"filename"`
+	FormatOverrides  PackagingFormat   `yaml:"formatOverrides"`
 	Binary           string            `yaml:"binary"`
 	TargetBinary     string            `yaml:"targetBinary"`
 	AdditionBinaries []string          `yaml:"additionBinaries"`


### PR DESCRIPTION
This PR handles support to construct the right path or the source package based on the type of OS the host is using.
fixes LinuxSuRen/http-downloader#137 along with https://github.com/LinuxSuRen/hd-home/pull/68 combined.