### PR TITLE
Some release asset files are not tar file

### DIFF
--- a/pkg/installer/check.go
+++ b/pkg/installer/check.go
@@ -190,6 +190,7 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 				}
 				o.Package = &cfg
 				o.AdditionBinaries = cfg.AdditionBinaries
+				o.Tar = cfg.Tar != "false"
 
 				if version == "latest" || version == "" {
 					ghClient := pkg.ReleaseClient{
@@ -235,7 +236,7 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 					if err = tmp.Execute(&buf, hdPkg); err == nil {
 						packageURL = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
 							o.Org, o.Repo, version, buf.String())
-						if !hasPackageSuffix(packageURL) {
+						if o.Tar && !hasPackageSuffix(packageURL) {
 							packageURL = fmt.Sprintf("%s.%s", packageURL, packagingFormat)
 						}
 						o.Output = buf.String()
@@ -257,7 +258,6 @@ func (o *Installer) ProviderURLParse(path string, acceptPreRelease bool) (packag
 					return
 				}
 
-				o.Tar = cfg.Tar != "false"
 				if cfg.Binary != "" {
 					if cfg.Binary, err = renderTemplate(cfg.Binary, hdPkg); err != nil {
 						return


### PR DESCRIPTION
This PR should be able to fix

https://github.com/LinuxSuRen/hd-home/pull/83

```shell
Run URL="https://api.github.com/repos/LinuxSuRen/hd-home/pulls/83/files"
filename: "{{.Name}}-{{.OS}}"
tar: false
replacements:
  linux: linux64
  macos: osx-amd64
  windows: win64
start to download from https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64.tar.gz
Error: cannot download from https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64.tar.gz, response error: failed to download from 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64.tar.gz': status code: 404, content length error: <nil>
Usage:
  hd install [flags]
```