### PR TITLE
Add upper-case proxy environment support

### DIFF
--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -80,3 +80,18 @@ func Exist(name string) bool {
 func ParseVersionNum(release string) string {
 	return regexp.MustCompile(`^.*v`).ReplaceAllString(release, "")
 }
+
+// GetEnvironment retrieves the value of the environment variable named by the key.
+// If the environment dosen't exist, we will lookup for alternative environment variables
+// unti we find an environment. Return empty environment value while no environment variables found.
+func GetEnvironment(key string, alternativeKeys ...string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	for _, alternativeKey := range alternativeKeys {
+		if value, exists := os.LookupEnv(alternativeKey); exists {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"fmt"
-	"github.com/magiconair/properties/assert"
+	"os"
 	"testing"
+
+	"github.com/magiconair/properties/assert"
 )
 
 func TestGetOrDefault(t *testing.T) {
@@ -41,4 +43,89 @@ type testCase struct {
 	def      string
 	data     map[string]string
 	expected string
+}
+
+func TestGetEnvironment(t *testing.T) {
+	type args struct {
+		key             string
+		alternativeKeys []string
+	}
+	tests := []struct {
+		name    string
+		initEnv func()
+		args    args
+		want    string
+	}{{
+		name: "Single key exists",
+		initEnv: func() {
+			os.Setenv("FAKE_KEY", "fake value")
+		},
+		args: args{
+			key: "FAKE_KEY",
+		},
+		want: "fake value",
+	}, {
+		name: "Single key non exist",
+		initEnv: func() {
+			os.Unsetenv("FAKE_KEY")
+		},
+		args: args{
+			key: "FAKE_ENV",
+		},
+		want: "",
+	}, {
+		name: "With one alternative key",
+		initEnv: func() {
+			os.Unsetenv("FAKE_KEY")
+			os.Setenv("alt_key", "alt_value")
+		},
+		args: args{
+			key:             "FAKE_KEY",
+			alternativeKeys: []string{"alt_key"},
+		},
+		want: "alt_value",
+	}, {
+		name: "With one alternative key but key exists",
+		initEnv: func() {
+			os.Setenv("FAKE_KEY", "fake_value")
+		},
+		args: args{
+			key:             "FAKE_KEY",
+			alternativeKeys: []string{"alt_key"},
+		},
+		want: "fake_value",
+	}, {
+		name: "With one alternative key but both of them exist",
+		initEnv: func() {
+			os.Setenv("FAKE_KEY", "fake_value")
+			os.Setenv("alt_key", "alt_value")
+		},
+		args: args{
+			key:             "FAKE_KEY",
+			alternativeKeys: []string{"alt_key"},
+		},
+		want: "fake_value",
+	}, {
+		name: "With two alternative keys",
+		initEnv: func() {
+			os.Unsetenv("FAKE_KEY")
+			os.Unsetenv("alt_key_1")
+			os.Setenv("alt_key_2", "alt_value_2")
+		},
+		args: args{
+			key:             "FAKE_KEY",
+			alternativeKeys: []string{"alt_key_1", "alt_key_2"},
+		},
+		want: "alt_value_2",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.initEnv != nil {
+				tt.initEnv()
+			}
+			if got := GetEnvironment(tt.args.key, tt.args.alternativeKeys...); got != tt.want {
+				t.Errorf("GetEnvironment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/net/http.go
+++ b/pkg/net/http.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/linuxsuren/http-downloader/pkg/common"
 )
 
 const (
@@ -72,28 +74,18 @@ func SetProxy(proxy, proxyAuth string, tr *http.Transport) (err error) {
 }
 
 func (h *HTTPDownloader) fetchProxyFromEnv(scheme string) {
-	allProxy := os.Getenv("ALL_PROXY")
-	if allProxy == "" {
-		allProxy = os.Getenv("all_proxy")
-	}
-	httpProxy := os.Getenv("HTTP_PROXY")
-	if httpProxy == "" {
-		os.Getenv("http_proxy")
-	}
-	httpsProxy := os.Getenv("HTTPS_PROXY")
-	if httpsProxy == "" {
-		os.Getenv("https_proxy")
-	}
-
+	allProxy := common.GetEnvironment("ALL_PROXY", "all_proxy")
 	if allProxy != "" {
 		h.Proxy = allProxy
 	} else {
 		switch scheme {
 		case "http":
+			httpProxy := common.GetEnvironment("HTTP_PROXY", "http_proxy")
 			if httpProxy != "" {
 				h.Proxy = httpProxy
 			}
 		case "https":
+			httpsProxy := common.GetEnvironment("HTTPS_PROXY", "https_proxy")
 			if httpsProxy != "" {
 				h.Proxy = httpsProxy
 			}


### PR DESCRIPTION
### What this PR dose?

Add upper-case proxy environment support.

### Why we need it?

There are some discussions about HTTP_PROXY environment and its friends: https://unix.stackexchange.com/questions/212894/whats-the-right-format-for-the-http-proxy-environment-variable-caps-or-no-ca.

/kind enhancement