### PR TITLE
Support to install hd via winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ curl -L https://github.com/linuxsuren/http-downloader/releases/latest/download/h
 mv hd /usr/bin/hd
 ```
 
+for Windows users:
+```
+winget install 'HTTP downloader'
+```
+
 Want to go through the code? [GitPod](https://gitpod.io/#https://github.com/linuxsuren/http-downloader) definitely can help you.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -L https://github.com/linuxsuren/http-downloader/releases/latest/download/h
 mv hd /usr/bin/hd
 ```
 
-for Windows users:
+for Windows users (you might need to add this program into the Windows Defence exclude list):
 ```
 winget install 'HTTP downloader'
 ```


### PR DESCRIPTION
Currently, we can install hd via winget. But there are some errors exist.
```
PS C:\> winget install 'HTTP downloader'
已找到 HTTP downloader [LinuxSuRen.HTTPdownloader] 版本 0.0.55
此应用程序由其所有者授权给你。
Microsoft 对第三方程序包概不负责，也不向第三方程序包授予任何许可证。
Downloading https://github.com/LinuxSuRen/http-downloader/releases/download/v0.0.55/hd-windows-amd64.msi
  ██████████████████████████████  4.48 MB / 4.48 MB
已成功验证安装程序哈希
正在启动程序包安装...
安装程序失败，退出代码为： 1603
安装程序日志在以下位置可用： C:\Users\xxx\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\DiagOutputDir\WinGet-LinuxSuRen.HTTPdownloader.0.0.55-2022-01-05-09-23-47.532.log
```